### PR TITLE
Optional printing of data value in popover

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This is the exploded view of possbile options (with included defaults)
     labelSize: 22,         // Popover Heading size
     metricSize: 14,        // Popover Metric size
     opacity: 0.6,
+    popoverShowData: true  // Show the data value of the bubble in the popover
   }
 }
 ```

--- a/src/classes/BubbleChart/Popover.coffee
+++ b/src/classes/BubbleChart/Popover.coffee
@@ -8,6 +8,9 @@ class BubbleChart.Popover
     @opacity = o.opacity or 0.8
     @labelSize = o.labelSize or 18
     @metricSize = o.metricSize or 12
+    @popoverShowData = true
+    if o.popoverShowData?
+      @popoverShowData = o.popoverShowData
     @last_draw = null
     @textDems = {}
     @pre = null
@@ -62,7 +65,11 @@ class BubbleChart.Popover
     tb_pad = 5 * ratio
     triangle_width = 16 * ratio
     triangle_height = 8 * ratio
-    metric_text = "#{@bubble.data} #{@bubble.metric}"
+
+    if this.popoverShowData
+      metric_text = "#{@bubble.data} #{@bubble.metric}"
+    else
+      metric_text = "#{@bubble.metric}"
 
     l_dems = @getTextDems context, @bubble.label, labelSize, @textFont
     m_dems = @getTextDems context, metric_text, metricSize, @textFont

--- a/test/classes/BubbleChart/PopoverTest.js
+++ b/test/classes/BubbleChart/PopoverTest.js
@@ -29,6 +29,7 @@
 			labelSize: 3,
 			metricSize: 5,
 			opacity: 5,
+			popoverShowData: true
 		});
 
 		equal(popover.fillColor, '#000');
@@ -37,6 +38,7 @@
 		equal(popover.labelSize, 3);
 		equal(popover.metricSize, 5);
 		equal(popover.opacity, 5);
+		equal(popover.popoverShowData, true);
 	});
 
 	test('constructor-defaults', function() {


### PR DESCRIPTION
The data value of a bubble was always printed in the popover. We needed to disable the printing of the data in the popover because the absolute values were not relevant for a few of our graphs. This was caused by the absolute values be approximations. This pull request introduces a key in the popoverOpts configuration dict with the name popoverShowData which can be set to false to disable the printing of data in the popover.
