### PR TITLE
Main entry set for package #3

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "grunt-contrib-watch": "0.5.3",
     "grunt-contrib-qunit": "0.2.2"
   },
+  "main": "./dist/bubblechart.js",
   "scripts": {
     "test": "grunt",
     "prepublish": "grunt dist"


### PR DESCRIPTION
Adds main entry point for `bubblechart` so it can be imported using requirejs or something similar.

_Warning:_ My tests did not pass locally, apparently because of changes in QUnit or PhantomJS. As last TravisCI build happened 1 year ago, going through a new build could impose some new issues and require more fixes.
